### PR TITLE
Added simple Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM ubuntu
+ENV PATH="/root/.local/bin:${PATH}"
+RUN apt-get update \
+&& apt-get -y install --no-install-recommends ca-certificates wget \
+&& wget -qO- https://get.haskellstack.org/ | sh \
+&& stack install qnap-decrypt


### PR DESCRIPTION
Added a simple Dockerfile to quickly spin up `qnap-decrypt` in order to decrypt select files that have been encrypted by the qnap NAS. fixes #1